### PR TITLE
Fix module header formatting in window.py

### DIFF
--- a/window.py
+++ b/window.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import webbrowser
-=======
 """wxPython GUI for caseMonster.
 
 Third-party dependencies:


### PR DESCRIPTION
## Summary
- remove the stray separator line between the imports and module docstring so the module can be imported cleanly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0fc80f74833281e6e57a858795ce