### PR TITLE
Add bundled help instructions and improve Help menu handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You do not need to press additional shortcuts beyond the button click. The appli
 - `Ctrl+C` to copy the selection.
 - `Ctrl+V` to paste the transformed text.
 
-The Help → "How to use" menu item attempts to open a `help.txt` file using the Windows `start` command if you want to provide extended documentation.
+The Help → "How to use" menu item opens the bundled [`help.txt`](./help.txt) guide in your default browser for a quick refresher on the buttons and automation workflow. If the file is missing, the app now shows an in-window message that explains how to restore it.
 
 ## Development Notes
 - `main.py` contains the case-conversion logic and the clipboard automation routines shared by the GUI.

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,41 @@
+WarpTyme - CASEmonster Help
+===========================
+
+Welcome! This guide explains how to make the most of the redesigned caseMonster window and its quick-access automation features.
+
+Launching the app
+-----------------
+1. Open a terminal in the project directory.
+2. Run `python window.py` to launch the **WarpTyme - CASEmonster** window.
+3. Keep the window somewhere convenient—it is designed to stay out of the way while you work in other applications.
+
+Using the quick-access buttons
+------------------------------
+Each button in the window applies a different transformation to your currently selected text:
+
+- **Upper**: Converts the selection to upper case.
+- **Title**: Title-cases every word in the selection.
+- **Lower**: Converts the selection to lower case.
+- **Sentence**: Applies sentence-style capitalization, including special handling for the pronoun "I" and punctuation that signals a new sentence.
+
+All buttons share the same streamlined workflow:
+
+1. Highlight the text to convert in any application.
+2. Click the desired button in caseMonster.
+3. The app automatically switches back to your previous window, copies the selection, applies the transformation, and pastes the result—no extra shortcuts required.
+
+Quick automation tips
+---------------------
+- Keep caseMonster focused only long enough to click a button. The built-in `Alt+Tab`, `Ctrl+C`, and `Ctrl+V` automation will return you to your work instantly.
+- If the clipboard already contains text you want to reuse, skip selecting new text and simply click a button; caseMonster will operate on whatever is currently on the clipboard.
+- Need to retry? Click the same button again. The automation is designed to be idempotent for the same source text.
+
+Troubleshooting
+---------------
+- **Nothing happens after clicking a button**: Confirm that the target application allows automated clipboard access (some administrative prompts may block it). Try selecting text again and repeat the button click.
+- **Text appears in the wrong case**: Undo in the target application and try a different button. The automation replays quickly, so experimenting is safe.
+- **Help window does not open**: Make sure this `help.txt` file stays next to `window.py`. If it is missing, the app will show an in-window message explaining how to restore it from the repository.
+
+More resources
+--------------
+For installation steps, dependency information, and development tips, check the project README in the repository root. You can open it in any text editor for additional context and contribution guidelines.

--- a/window.py
+++ b/window.py
@@ -1,13 +1,11 @@
-from pathlib import Path
-import webbrowser
-=======
 """wxPython GUI for caseMonster.
 
 Third-party dependencies:
 - wxPython (tested with 4.2.1)
 """
 
-import os
+from pathlib import Path
+import webbrowser
 
 from main import lower_case, title_case, upper_case, funky_case
 
@@ -131,13 +129,27 @@ class MONSTERcase(wx.Frame):
     def m_menuItem1OnMenuSelection(self, event):
         help_file = Path(__file__).with_name("help.txt")
         if not help_file.exists():
-            wx.LogError(f"Help file not found: {help_file}")
+            wx.MessageBox(
+                "The help guide could not be found.\n\n"
+                "Expected location:\n"
+                f"{help_file}\n\n"
+                "Restore 'help.txt' from the repository to re-enable this menu option.",
+                "Help unavailable",
+                wx.OK | wx.ICON_INFORMATION,
+                parent=self,
+            )
             return
 
         try:
             webbrowser.open(help_file.resolve().as_uri())
         except Exception as exc:
-            wx.LogError(f"Unable to open help file: {exc}")
+            wx.MessageBox(
+                "caseMonster could not open the help guide.\n\n"
+                f"Details: {exc}",
+                "Help unavailable",
+                wx.OK | wx.ICON_ERROR,
+                parent=self,
+            )
         event.Skip()
 
 


### PR DESCRIPTION
## Summary
- add a help.txt guide at the project root describing the updated UI workflow and quick automation tips
- update the Help menu handler to show a helpful message box if the guide is missing or cannot be opened
- mention the Help menu resource in the README so users know where to find extended instructions

## Testing
- python -m compileall main.py window.py

------
https://chatgpt.com/codex/tasks/task_e_68da0ffd8b388332aa0bbaed7ff1745b