### PR TITLE
Handle sentence-case pronoun i at sentence end

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,8 +64,11 @@ def _cap_first_letter(characters: list[str]) -> list[str]:
                 char.lower() == "i"
                 and fin_list
                 and fin_list[-1] == " "
-                and index + 1 < len(characters)
-                and characters[index + 1] == " "
+                and (
+                    index + 1 == len(characters)
+                    or characters[index + 1]
+                    in [" ", ".", "!", "?", "\n"]
+                )
             ):
                 fin_list.append(char.upper())
             elif (

--- a/tests/test_sentence_case.py
+++ b/tests/test_sentence_case.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+stub = types.SimpleNamespace()
+sys.modules.setdefault("pyautogui", stub)
+sys.modules.setdefault("pyperclip", types.SimpleNamespace(copy=lambda *_: None, paste=lambda: ""))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import convert_text
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("you and i.", "You and I."),
+        ("you and i!", "You and I!"),
+        ("you and i?", "You and I?"),
+        ("you and i\n", "You and I"),
+    ],
+)
+def test_sentence_case_pronoun_i_followed_by_punctuation(source: str, expected: str) -> None:
+    assert convert_text(source, "sentence") == expected


### PR DESCRIPTION
## Summary
- extend sentence casing rules so standalone "i" is capitalized at punctuation boundaries
- add regression tests covering punctuation and newline termination cases for the pronoun "I"

## Testing
- pytest tests/test_sentence_case.py

------
https://chatgpt.com/codex/tasks/task_e_68da139de1e88332b9eeb0dd18193e09