### PR TITLE
Preserve whitespace when applying sentence case

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ Transform = Callable[[str], str]
 def _cap_sentences(text: str) -> str:
     sentences = text.split(".")
     transformed = ["".join(_cap_first_letter(list(sentence))) for sentence in sentences]
-    return _cap_special(".".join(transformed).strip())
+    return _cap_special(".".join(transformed))
 
 
 def _cap_special(text: str) -> str:
@@ -42,7 +42,7 @@ def _cap_special(text: str) -> str:
         else:
             fin.append(char)
 
-    return "".join(fin).strip()
+    return "".join(fin)
 
 
 def _cap_first_letter(characters: list[str]) -> list[str]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("pyautogui", types.SimpleNamespace(hotkey=lambda *_, **__: None))
+sys.modules.setdefault(
+    "pyperclip",
+    types.SimpleNamespace(copy=lambda *_: None, paste=lambda: ""),
+)
+
+from main import convert_text
+
+
+def test_sentence_case_preserves_leading_and_trailing_spaces():
+    text = "  hello world.  "
+    result = convert_text(text, "sentence")
+    assert result == "  Hello world.  "
+
+
+def test_sentence_case_preserves_newline_padding():
+    text = "\nhello universe.\n"
+    result = convert_text(text, "sentence")
+    assert result == "\nHello universe.\n"


### PR DESCRIPTION
## Summary
- stop `_cap_sentences` and `_cap_special` from stripping the transformed text so outer whitespace survives
- add targeted tests that assert sentence-case conversion keeps leading/trailing spaces and newlines

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68da139674d8833283d89620070b1b0a