### PR TITLE
Fix Windows context menu error message strings

### DIFF
--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -118,8 +118,7 @@ class SettingsDialog(wx.Dialog):
             )
         except Exception as exc:  # pragma: no cover - runtime diagnostics
             wx.MessageBox(
-                f"Unable to register context menu entries:
-{exc}",
+                f"Unable to register context menu entries:\n{exc}",
                 "caseMonster",
                 style=wx.OK | wx.ICON_ERROR,
             )
@@ -136,8 +135,7 @@ class SettingsDialog(wx.Dialog):
             )
         except Exception as exc:  # pragma: no cover - runtime diagnostics
             wx.MessageBox(
-                f"Unable to remove context menu entries:
-{exc}",
+                f"Unable to remove context menu entries:\n{exc}",
                 "caseMonster",
                 style=wx.OK | wx.ICON_ERROR,
             )


### PR DESCRIPTION
## Summary
- fix the Windows Explorer context menu error messages so they format correctly

## Testing
- python -m compileall ui/dialogs.py

------
https://chatgpt.com/codex/tasks/task_e_68db6e69780c8332899fa3c88ceed8df