### PR TITLE
Restore dark theme and stabilize accent button painting

### DIFF
--- a/ui/components.py
+++ b/ui/components.py
@@ -90,12 +90,14 @@ class AccentButton(wx.Button):
         self.SetFont(styles.get_font("button"))
         self.SetForegroundColour(styles.BUTTON_TEXT_COLOUR)
         self.SetBackgroundColour(self._base_colour)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
 
         self.Bind(wx.EVT_ENTER_WINDOW, self._on_hover)
         self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
         self.Bind(wx.EVT_LEFT_DOWN, self._on_press)
         self.Bind(wx.EVT_LEFT_UP, self._on_release)
         self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_ERASE_BACKGROUND, lambda event: None)
 
     def _set_colour(self, colour: wx.Colour) -> None:
         self.SetBackgroundColour(colour)

--- a/ui/main_frame.py
+++ b/ui/main_frame.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import wx
 
 from . import actions, styles
-from .assets import load_bitmap, load_icon
+from .assets import load_icon
 from .components import (
     AccentButton,
     FeatureList,
@@ -21,38 +21,35 @@ class HeroPanel(RoundedPanel):
     """Hero-style header that introduces the application purpose."""
 
     def __init__(self, parent: wx.Window):
-        background = wx.Colour(230, 237, 252)
+        background = wx.Colour(40, 48, 66)
         super().__init__(parent, radius=22, padding=24, background=background)
         self.SetBackgroundColour(background)
 
-        layout = wx.BoxSizer(wx.HORIZONTAL)
-        column = wx.BoxSizer(wx.VERTICAL)
+        layout = wx.BoxSizer(wx.VERTICAL)
+
+        brand = wx.StaticText(self, label="caseMonster")
+        brand.SetFont(styles.get_font("display"))
+        brand.SetForegroundColour(styles.ACCENT_PRIMARY)
+        layout.Add(brand, 0)
+
+        layout.AddSpacer(6)
 
         title = wx.StaticText(self, label="Clipboard stylist")
         title.SetFont(styles.get_font("headline"))
         title.SetForegroundColour(styles.FOREGROUND_COLOUR)
-        column.Add(title, 0)
+        layout.Add(title, 0)
 
         subtitle = create_caption(
             self,
             "Convert your copied text into the perfect tone before you paste it anywhere.",
         )
-        column.Add(subtitle, 0, wx.TOP, 4)
+        layout.Add(subtitle, 0, wx.TOP, 4)
 
         self._subtitle = subtitle
 
         self._status = create_caption(self, "Always on top: on")
         self._status.SetForegroundColour(styles.ACCENT_SECONDARY)
-        column.Add(self._status, 0, wx.TOP, 12)
-
-        layout.Add(column, 1, wx.EXPAND)
-
-        bitmap = load_bitmap('logo.png')
-        self._image_width = 0
-        if bitmap:
-            image = wx.StaticBitmap(self, wx.ID_ANY, bitmap)
-            self._image_width = bitmap.GetWidth()
-            layout.Add(image, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 16)
+        layout.Add(self._status, 0, wx.TOP, 12)
 
         self.content_sizer.Add(layout, 0, wx.EXPAND)
         self.Bind(wx.EVT_SIZE, self._on_size)
@@ -65,11 +62,8 @@ class HeroPanel(RoundedPanel):
 
     def refresh_layout(self) -> None:
         available = max(self.content_width(), 180)
-        text_width = available
-        if self._image_width:
-            text_width = max(available - self._image_width - 16, 160)
-        self._subtitle.Wrap(text_width)
-        self._status.Wrap(text_width)
+        self._subtitle.Wrap(available)
+        self._status.Wrap(available)
         self.Layout()
 
     def _on_size(self, event: wx.SizeEvent) -> None:

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -8,18 +8,18 @@ from typing import Dict
 
 import wx
 
-# Core brand palette
-BACKGROUND_COLOUR = wx.Colour(244, 247, 252)
-FOREGROUND_COLOUR = wx.Colour(24, 32, 45)
-ACCENT_PRIMARY = wx.Colour(64, 106, 255)
-ACCENT_SECONDARY = wx.Colour(24, 151, 111)
-ACCENT_TERTIARY = wx.Colour(230, 124, 48)
-ACCENT_NEUTRAL = wx.Colour(101, 116, 139)
-CONTAINER_BACKGROUND = wx.Colour(255, 255, 255)
-CONTAINER_BORDER = wx.Colour(219, 225, 238)
-SUBTLE_TEXT = wx.Colour(92, 106, 133)
-BORDER_SUBTLE = wx.Colour(209, 216, 230)
-BUTTON_TEXT_COLOUR = wx.Colour(255, 255, 255)
+# Core brand palette – tuned for the restored dark theme
+BACKGROUND_COLOUR = wx.Colour(18, 22, 32)
+FOREGROUND_COLOUR = wx.Colour(228, 236, 255)
+ACCENT_PRIMARY = wx.Colour(84, 160, 255)
+ACCENT_SECONDARY = wx.Colour(72, 205, 160)
+ACCENT_TERTIARY = wx.Colour(255, 166, 105)
+ACCENT_NEUTRAL = wx.Colour(132, 146, 172)
+CONTAINER_BACKGROUND = wx.Colour(30, 38, 52)
+CONTAINER_BORDER = wx.Colour(52, 61, 80)
+SUBTLE_TEXT = wx.Colour(168, 181, 206)
+BORDER_SUBTLE = wx.Colour(46, 54, 72)
+BUTTON_TEXT_COLOUR = wx.Colour(12, 16, 24)
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,7 @@ _FONT_DEFINITIONS: Dict[str, FontDefinition] = {
     "base": FontDefinition(11, wx.FONTWEIGHT_NORMAL, "Segoe UI"),
     "headline": FontDefinition(17, wx.FONTWEIGHT_BOLD, "Segoe UI Semibold"),
     "button": FontDefinition(11, wx.FONTWEIGHT_BOLD, "Segoe UI"),
+    "display": FontDefinition(24, wx.FONTWEIGHT_BOLD, "Segoe UI Semibold"),
     "caption": FontDefinition(10, wx.FONTWEIGHT_NORMAL, "Segoe UI"),
     "mono": FontDefinition(10, wx.FONTWEIGHT_NORMAL, "Cascadia Code"),
 }


### PR DESCRIPTION
## Summary
- reinstate a dark colour palette and typography update to match the refreshed theme
- simplify the hero header layout with a textual logo and remove the bitmap to reduce clutter
- fix accent button painting by enabling buffered paint handling to prevent wx assertions

## Testing
- pytest tests/test_sentence_case.py

------
https://chatgpt.com/codex/tasks/task_e_68db75f780148332afde7f0e9ff8f0dd