### PR TITLE
Fix settings dialog button row

### DIFF
--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -89,13 +89,14 @@ class SettingsDialog(wx.Dialog):
         footer.Wrap(360)
         body.Add(footer, 0, wx.TOP, 6)
 
-        action_row = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
-        if action_row:
-            action_row.Realize()
-            ok_button = action_row.GetOkButton()
-            if ok_button:
-                ok_button.SetLabel("Save")
-            body.Add(action_row, 0, wx.ALIGN_RIGHT | wx.TOP, 6)
+        action_row = wx.StdDialogButtonSizer()
+        ok_button = wx.Button(container, wx.ID_OK, "Save")
+        ok_button.SetDefault()
+        cancel_button = wx.Button(container, wx.ID_CANCEL)
+        action_row.AddButton(ok_button)
+        action_row.AddButton(cancel_button)
+        action_row.Realize()
+        body.Add(action_row, 0, wx.ALIGN_RIGHT | wx.TOP, 6)
 
         outer_sizer = wx.BoxSizer(wx.VERTICAL)
         outer_sizer.Add(container, 1, wx.EXPAND | wx.ALL, 14)


### PR DESCRIPTION
## Summary
- build the settings dialog button row with buttons parented to the container panel to avoid sizer conflicts
- set the Save button as the default action when the dialog opens

## Testing
- python -m compileall ui/dialogs.py

------
https://chatgpt.com/codex/tasks/task_e_68db7c2eea2c8332bba909aaa469eec1