### PR TITLE
Fix washed out styling on Windows

### DIFF
--- a/ui/main_frame.py
+++ b/ui/main_frame.py
@@ -243,8 +243,18 @@ class CaseMonsterFrame(wx.Frame):
         self._hero.update_status(self.always_on_top)
 
     def _apply_shadow_effect(self):
+        """Hint at a drop shadow without washing out the UI."""
+
         if "WX_MAC" in wx.PlatformInfo:
             return
+
+        # Windows already provides a drop shadow and applying SetTransparent
+        # makes the whole window semi-opaque, which results in the washed out
+        # look reported by users. Keep the behaviour for GTK where it helps to
+        # soften the window edges, but otherwise skip it.
+        if "WXMSW" in wx.PlatformInfo:
+            return
+
         try:
             self.SetTransparent(245)
         except wx.NotImplementedError:


### PR DESCRIPTION
## Summary
- skip the transparency tweak on Windows to prevent the frame from becoming semi-opaque
- document why the shadow helper is a no-op on macOS and Windows

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68db7e093afc8332b8c5b997024fb8d1